### PR TITLE
PR incluindo correção de pop-up e melhoria na visualização de agendamento por Timeline

### DIFF
--- a/resources/js/components/ui/photo-upload.tsx
+++ b/resources/js/components/ui/photo-upload.tsx
@@ -15,6 +15,7 @@ import {
     AlertDialogTrigger,
 } from '@/components/ui/alert-dialog';
 import { Upload, X, Image as ImageIcon, Edit2, Trash2, Save, XCircle } from 'lucide-react';
+import { useToast } from '@/hooks/use-toast';
 
 interface Foto {
     id?: number;
@@ -43,6 +44,7 @@ export function PhotoUpload({
     maxFileSize = 5,
     className = ""
 }: PhotoUploadProps) {
+    const { toast } = useToast();
     const [fotosLocal, setFotosLocal] = useState<Foto[]>(fotos);
     const [arquivosOriginais, setArquivosOriginais] = useState<File[]>([]);
     const [uploading, setUploading] = useState(false);
@@ -73,7 +75,12 @@ export function PhotoUpload({
         
         // Validar número máximo de arquivos
         if (fotosLocal.length + files.length > maxFiles) {
-            alert(`Máximo de ${maxFiles} fotos permitidas`);
+            toast({
+                title: 'Limite de fotos excedido',
+                description: `Máximo de ${maxFiles} fotos permitidas`,
+                variant: 'destructive',
+                duration: 5000,
+            });
             return;
         }
 

--- a/resources/js/pages/Agendamentos/AgendamentosCalendar.tsx
+++ b/resources/js/pages/Agendamentos/AgendamentosCalendar.tsx
@@ -37,7 +37,7 @@ interface CalendarProps {
     getEventsForDay: (date: Date) => Agendamento[];
     getEventsForTimeSlot: (date: Date, timeSlot: string) => Agendamento[];
     getEventTooltip: (event: Agendamento, includeTime?: boolean) => string;
-    handleDateSelect: (date: Date, timeSlot?: string, preserveEspaco?: boolean) => void;
+    handleDateSelect: (date: Date, timeSlot?: string, preserveEspaco?: boolean, espacoId?: number) => void;
     handleDayClick: (date: Date, events: Agendamento[], espacoId?: number) => void;
     handleEventClick: (agendamento: Agendamento) => void;
     setDayViewModal: (modal: { open: boolean; selectedDate: Date | null; events: Agendamento[] }) => void;
@@ -958,7 +958,7 @@ export default function AgendamentosCalendar({
                                             className="h-[160px] w-full p-2 border-2 border-border/100 hover:border-border/60 rounded cursor-pointer hover:bg-muted/30 transition-all duration-200 overflow-hidden"
                                             onClick={() => {
                                                 setFormData(prev => ({ ...prev, espaco_id: espaco.id.toString() }));
-                                                handleDateSelect(day, undefined, true);
+                                                handleDateSelect(day, undefined, true, espaco.id);
                                             }}
                                         >
                                             <div className="space-y-1 h-full pr-1">

--- a/resources/js/pages/Agendamentos/Create.tsx
+++ b/resources/js/pages/Agendamentos/Create.tsx
@@ -469,7 +469,7 @@ export default function AgendamentosCreate({ espacos, recursos, espacoSelecionad
                                     <div className="space-y-4">
                                         <Button
                                             type="submit"
-                                            className="w-full"
+                                            className="w-full cursor-pointer"
                                             disabled={isFormDisabled}
                                         >
                                             {isFormDisabled ? 'Enviando...' : 'Solicitar Agendamento'}
@@ -477,7 +477,7 @@ export default function AgendamentosCreate({ espacos, recursos, espacoSelecionad
 
                                         <Button 
                                             variant="outline" 
-                                            className="w-full" 
+                                            className="w-full cursor-pointer" 
                                             asChild
                                             disabled={isFormDisabled}
                                         >

--- a/resources/js/pages/Agendamentos/Index.tsx
+++ b/resources/js/pages/Agendamentos/Index.tsx
@@ -744,7 +744,7 @@ export default function AgendamentosIndex({ agendamentos, espacos, filters, auth
         return selectedDateTime <= now;
     };
 
-    const handleDateSelect = (date: Date, timeSlot?: string, preserveEspaco?: boolean) => {
+    const handleDateSelect = (date: Date, timeSlot?: string, preserveEspaco?: boolean, espacoId?: number) => {
         const selectedDate = format(date, 'yyyy-MM-dd');
         const now = new Date();
         const todayStr = format(now, 'yyyy-MM-dd');
@@ -780,7 +780,7 @@ export default function AgendamentosIndex({ agendamentos, espacos, filters, auth
 
         const newFormData = {
             titulo: '',
-            espaco_id: preserveEspaco ? formData.espaco_id : '',
+            espaco_id: espacoId ? espacoId.toString() : (preserveEspaco ? formData.espaco_id : ''),
             data_inicio: selectedDate,
             hora_inicio: selectedTime,
             data_fim: selectedDate,
@@ -812,11 +812,18 @@ export default function AgendamentosIndex({ agendamentos, espacos, filters, auth
             open: true,
             selectedDate,
             selectedTime,
-            selectedEspaco: selectedEspacos[0]
+            selectedEspaco: espacoId ? espacoId : selectedEspacos[0]
         });
     };
 
     const handleEventClick = (agendamento: Agendamento) => {
+        // Se estamos na visualização timeline, preservar o espaço do agendamento clicado
+        if (viewMode === 'timeline') {
+            setFormData(prev => ({ 
+                ...prev, 
+                espaco_id: agendamento.espaco_id.toString() 
+            }));
+        }
         router.get(`/agendamentos/${agendamento.id}`);
     };
 


### PR DESCRIPTION
Antes, ao tentar adicionar mais do que 10 fotos na criação de um Espaço, o sistema apresentava um pop-up fora do padrão adotado pela nossa equipe de desenvolvimento, mantinha um padrão do framework. Agora, está no nosso padrão.

Antes, ao agendar um espaço pela visualização de Timeline, o modal aberto não possuía o espaço setado. Agora, o espaço já é definido a partir do momento em que o modal e aberto!